### PR TITLE
feat: show child destinations

### DIFF
--- a/src/core/entities/Destination.ts
+++ b/src/core/entities/Destination.ts
@@ -1,4 +1,4 @@
-export type DestinationId = number;
+export type DestinationId = string;
 
 export type DestinationEntity = {
   id: DestinationId;

--- a/src/core/entities/Destination.ts
+++ b/src/core/entities/Destination.ts
@@ -1,8 +1,9 @@
-type DestinationId = number;
+export type DestinationId = number;
 
 export type DestinationEntity = {
   id: DestinationId;
   name: string;
   isFeatured: boolean;
-  isLastOne: boolean;
+  hasChildren: boolean;
+  childs: DestinationEntity[];
 };

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/DestinationsGateway.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/DestinationsGateway.ts
@@ -1,7 +1,7 @@
 import HttpInstance from '../../../instances/HttpInstance';
 import { Response } from '../types';
 import { DestinationEntity } from '../../../../entities/Destination';
-import { mapDestination } from './mappers';
+import { mapDestinationsList } from './mappers';
 import { Destination } from './types';
 
 type GetDestinationsResponse = Response<Destination[]>;
@@ -21,7 +21,7 @@ type GetDestinationsResponse = Response<Destination[]>;
 
 const getDestinations = async (): Promise<DestinationEntity[]> => 
   HttpInstance.get<GetDestinationsResponse>('/v1/establishments/destinations')
-    .then(({ data }) => data.data.map(mapDestination));
+    .then(({ data }) => mapDestinationsList(data.data));
     // TODO: map the error and handle it
 
 export default {

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/fixtures.test.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/fixtures.test.ts
@@ -1,0 +1,31 @@
+import { createDestinationFixture } from './fixtures';
+
+describe('createDestinationFixture function', () => {
+  it('creates a destination object with the specified ID', () => {
+    const output = createDestinationFixture({ id: 1 });
+
+    expect(output).toEqual({
+      childs: [],
+      destinationData: {
+        translatableName: {
+          de: `Translated Name 1 (DE)`,
+          en: `Translated Name 1 (EN)`,
+          es: `Translated Name 1 (ES)`,
+          fr: `Translated Name 1 (FR)`,
+          it: `Translated Name 1 (IT)`,
+          pt: `Translated Name 1 (PT)`,
+        },
+        coordinates: {
+          latitude: 12.3456789,
+          longitude: -12.3456789,
+        },
+        photographs: ['1111', '2222', '3333'],
+      },
+      fatherDestination: 0,
+      id: 1,
+      isTop: true,
+      isFinalNode: true,
+      numEstablishments: 0,
+    });
+  });
+});

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/fixtures.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/fixtures.ts
@@ -1,0 +1,33 @@
+import { Destination, DestinationId } from './types';
+
+type CreateDestinationFixtureProps = {
+  id: DestinationId;
+  config?: Omit<Partial<Destination>, 'id'>;
+};
+
+export const createDestinationFixture = ({ id, config }: CreateDestinationFixtureProps): Destination => {
+  return {
+    childs: [],
+    destinationData: {
+      translatableName: {
+        de: `Translated Name ${id} (DE)`,
+        en: `Translated Name ${id} (EN)`,
+        es: `Translated Name ${id} (ES)`,
+        fr: `Translated Name ${id} (FR)`,
+        it: `Translated Name ${id} (IT)`,
+        pt: `Translated Name ${id} (PT)`,
+      },
+      coordinates: {
+        latitude: 12.3456789,
+        longitude: -12.3456789,
+      },
+      photographs: ['1111', '2222', '3333'],
+    },
+    fatherDestination: 0,
+    id,
+    isTop: true,
+    isFinalNode: true,
+    numEstablishments: 0,
+    ...config,
+  };
+};

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.test.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.test.ts
@@ -1,41 +1,35 @@
-import { mapDestination } from './mappers';
+import { createDestinationFixture } from './fixtures';
+import { mapDestination, mapDestinationsList } from './mappers';
 
-// TODO: This must be created by a fixture factory that returns customizable destinations
-const DESTINATION_FIXTURE = {
-  childs: [],
-  destinationData: {
-    translatableName: {
-      de: 'Dominikanische Republik',
-      en: 'Dominican Republic',
-      es: 'República Dominicana',
-      fr: 'République Dominicaine',
-      it: 'Repubblica Dominicana',
-      pt: 'República Dominicana',
-    },
-    coordinates: {
-      latitude: 18.4860575,
-      longitude: -69.9312117,
-    },
-    photographs: ['132379'],
-  },
-  fatherDestination: 0,
-  id: 99,
-  isTop: true,
-  isFinalNode: true,
-  numEstablishments: 0,
-};
+const DESTINATIONS_LIST_FIXTURE = [
+  createDestinationFixture({ id: 1 }),
+  createDestinationFixture({ id: 2 }),
+];
 
 describe('EstablishmentsGateway mappers', () => {
   describe('mapDestination mapper', () => {
     it('maps api destination object to a destination entity', () => {
+      const DESTINATION_FIXTURE = DESTINATIONS_LIST_FIXTURE[0];
       const output = mapDestination(DESTINATION_FIXTURE);
   
       expect(output).toEqual({
         id: DESTINATION_FIXTURE.id,
         name: DESTINATION_FIXTURE.destinationData.translatableName.es,
         isFeatured: DESTINATION_FIXTURE.isTop,
-        isLastOne: DESTINATION_FIXTURE.isFinalNode,
+        hasChildren: !DESTINATION_FIXTURE.isFinalNode,
+        childs: [],
       });
+    });
+  });
+
+  describe('mapDestinationsList mapper', () => {
+    it('maps api destination object array to a destination entity array', () => {
+      const output = mapDestinationsList(DESTINATIONS_LIST_FIXTURE);
+  
+      expect(output).toEqual([
+        mapDestination(DESTINATIONS_LIST_FIXTURE[0]),
+        mapDestination(DESTINATIONS_LIST_FIXTURE[1]),
+      ]);
     });
   });
 });

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.test.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.test.ts
@@ -13,7 +13,7 @@ describe('EstablishmentsGateway mappers', () => {
       const output = mapDestination(DESTINATION_FIXTURE);
   
       expect(output).toEqual({
-        id: DESTINATION_FIXTURE.id,
+        id: `${DESTINATION_FIXTURE.id}`,
         name: DESTINATION_FIXTURE.destinationData.translatableName.es,
         isFeatured: DESTINATION_FIXTURE.isTop,
         hasChildren: !DESTINATION_FIXTURE.isFinalNode,

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.ts
@@ -7,7 +7,7 @@ import { Destination } from './types';
 export const mapDestinationsList: Mapper<Destination[], DestinationEntity[]> = input => input.map(mapDestination);
 
 export const mapDestination: Mapper<Destination, DestinationEntity> = input => ({
-  id: input.id,
+  id: input.id.toString(),
   name: getTranslatableName(input.destinationData.translatableName),
   isFeatured: input.isTop,
   hasChildren: !input.isFinalNode,

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/mappers.ts
@@ -4,9 +4,12 @@ import { Mapper } from '../../../../../utils/types/mapper.types';
 import { DestinationEntity } from '../../../../entities/Destination';
 import { Destination } from './types';
 
+export const mapDestinationsList: Mapper<Destination[], DestinationEntity[]> = input => input.map(mapDestination);
+
 export const mapDestination: Mapper<Destination, DestinationEntity> = input => ({
   id: input.id,
   name: getTranslatableName(input.destinationData.translatableName),
   isFeatured: input.isTop,
-  isLastOne: input.isFinalNode,
+  hasChildren: !input.isFinalNode,
+  childs: input.childs && input.childs.length > 0 ? mapDestinationsList(input.childs) : [],
 });

--- a/src/core/infrastructure/gateways/V1/EstablishmentsGateway/types.ts
+++ b/src/core/infrastructure/gateways/V1/EstablishmentsGateway/types.ts
@@ -1,6 +1,6 @@
 import { TranslatableName, Coordinates } from '../types';
 
-type DestinationId = number;
+export type DestinationId = number;
 
 type DestinationData = {
   translatableName: TranslatableName;

--- a/src/core/usecases/useDestinationsList.test.tsx
+++ b/src/core/usecases/useDestinationsList.test.tsx
@@ -5,7 +5,7 @@ import QueryHookWrapper from '../../utils/test/QueryHookWrapper';
 
 describe('useDestinationsList hook', () => {
   it('calls the getDestinations gateway method', async () => {
-    const FAKE_GET_DESTINATIONS_RESPONSE = [{ id: 1, name: 'example', isFeatured: false, isLastOne: false }];
+    const FAKE_GET_DESTINATIONS_RESPONSE = [{ id: 1, name: 'example', isFeatured: false, hasChildren: false }];
     const mockGetDestinations = jest.fn();
     
     jest.spyOn(DestinationsGateway, 'getDestinations').mockImplementation(mockGetDestinations).mockResolvedValue(FAKE_GET_DESTINATIONS_RESPONSE);

--- a/src/core/usecases/useDestinationsList.test.tsx
+++ b/src/core/usecases/useDestinationsList.test.tsx
@@ -2,10 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react-native';
 import useDestinationsList from './useDestinationsList';
 import DestinationsGateway from '../infrastructure/gateways/V1/EstablishmentsGateway/DestinationsGateway';
 import QueryHookWrapper from '../../utils/test/QueryHookWrapper';
+import { DestinationEntity } from '../entities/Destination';
 
 describe('useDestinationsList hook', () => {
   it('calls the getDestinations gateway method', async () => {
-    const FAKE_GET_DESTINATIONS_RESPONSE = [{ id: 1, name: 'example', isFeatured: false, hasChildren: false }];
+    const FAKE_GET_DESTINATIONS_RESPONSE: DestinationEntity[] = [{ id: '1', name: 'example', isFeatured: false, hasChildren: false, childs: [] }];
     const mockGetDestinations = jest.fn();
     
     jest.spyOn(DestinationsGateway, 'getDestinations').mockImplementation(mockGetDestinations).mockResolvedValue(FAKE_GET_DESTINATIONS_RESPONSE);

--- a/src/ui/components/TreeList.test.tsx
+++ b/src/ui/components/TreeList.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import TreeList, { TreeItemData } from './TreeList';
+
+const ON_OPEN = jest.fn();
+
+const FAKE_TREE_ITEM_DATA: TreeItemData[] = [
+  {
+    id: '1',
+    title: 'Item 1',
+    childs: [
+      {
+        id: '11',
+        title: 'Item 1.1',
+        childs: [],
+      },
+      {
+        id: '12',
+        title: 'Item 1.2',
+        childs: [],
+      },
+    ],
+  },
+  {
+    id: '2',
+    title: 'Item 2',
+    childs: [],
+  },
+];
+
+const renderElement = () => {
+  const rendered = render(<TreeList items={FAKE_TREE_ITEM_DATA} onOpen={ON_OPEN} />);
+
+  return rendered;
+};
+
+describe('<TreeList /> component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders expected provided items', () => {
+    const { queryByText } = renderElement();
+    
+    expect(queryByText('Item 1')).not.toBeNull();
+    expect(queryByText('Item 2')).not.toBeNull();
+  });
+
+  it('calls onOpen when a leaf item is pressed', () => {
+    const { queryByText } = renderElement();
+    
+    fireEvent.press(queryByText('Item 2')!);
+
+    expect(ON_OPEN).toHaveBeenCalledWith('2');
+  });
+
+  it('shows collapsed child items when an item with child items is pressed', () => {
+    const { queryByText } = renderElement();
+    
+    fireEvent.press(queryByText('Item 1')!);
+
+    expect(queryByText('Item 1.1')).not.toBeNull();
+    expect(queryByText('Item 1.2')).not.toBeNull();
+  });
+
+  it('toggles collapse when an item with child items is pressed', () => {
+    const { queryByText } = renderElement();
+    
+    fireEvent.press(queryByText('Item 1')!);
+
+    expect(queryByText('Item 1.1')).not.toBeNull();
+    expect(queryByText('Item 1.2')).not.toBeNull();
+    expect(ON_OPEN).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/TreeList.tsx
+++ b/src/ui/components/TreeList.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { View, FlatList, ListRenderItem, Text, TouchableOpacity, ViewStyle } from 'react-native';
+import { toggleArrayItem } from '../../utils/helpers';
+
+export type TreeItemData = {
+  id: string;
+  title: string;
+  childs: TreeItemData[];
+};
+
+type TreeListProps = {
+  items: TreeItemData[];
+  style?: ViewStyle;
+  onOpen: (id: TreeItemData['id']) => void;
+};
+
+const TreeList: React.FC<TreeListProps> = ({ items, style, onOpen }) => {
+  const [openedItems, setOpenedItems] = useState<TreeItemData['id'][]>([]);
+
+  const toggleCollapse = (id: TreeItemData['id']) => {
+    setOpenedItems(prev => toggleArrayItem(prev, id));
+  };
+
+  const TreeListItem: ListRenderItem<TreeItemData> = ({ item }) => {
+    const hasChildItems = item.childs.length > 0;
+    const isCollapsed = !openedItems.includes(item.id);
+
+    const handlePress = () => {
+      if (hasChildItems) {
+        toggleCollapse(item.id);
+      } else {
+        onOpen(item.id);
+      }
+    };
+  
+    return (
+      <View style={style}>
+        <TouchableOpacity onPress={handlePress}>
+          <View style={{ borderWidth: 1, borderRadius: 6, margin: 8, padding: 16, borderColor: '#DDD' }}>
+            <Text style={{ fontSize: 16 }}>{item.title}</Text>
+          </View>
+        </TouchableOpacity>
+        { hasChildItems && !isCollapsed && (
+          <TreeList style={{ marginLeft: 20 }} items={item.childs} onOpen={onOpen} />
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <FlatList style={{}} data={items} renderItem={TreeListItem} />
+  );
+};
+
+export default TreeList;

--- a/src/ui/screens/DestinationsScreen.tsx
+++ b/src/ui/screens/DestinationsScreen.tsx
@@ -1,67 +1,35 @@
-import React, { useState } from 'react';
-import { View, FlatList, ListRenderItem, Text, TouchableOpacity, ViewStyle } from 'react-native';
+import React, { useMemo } from 'react';
+import { Text } from 'react-native';
 import Screen from '../components/Screen';
+import TreeList, { TreeItemData } from '../components/TreeList';
 import useDestinationsList from '../../core/usecases/useDestinationsList';
-import { DestinationEntity, DestinationId } from '../../core/entities/Destination';
-import { toggleArrayItem } from '../../utils/helpers';
-
-type DestinationsListProps = {
-  items: DestinationEntity[];
-  style?: ViewStyle;
-};
-
-const DestinationsList: React.FC<DestinationsListProps> = ({ items, style }) => {
-  const [openedItems, setOpenedItems] = useState<DestinationId[]>([]);
-
-  const toggleCollapse = (id: DestinationId) => {
-    setOpenedItems(prev => toggleArrayItem(prev, id));
-  };
-
-  const handleOpen = (id: DestinationId) => {
-
-  };
-
-  const DestinationsListItem: ListRenderItem<DestinationEntity> = ({ item }) => {
-    const hasChildItems = item.hasChildren && item.childs.length > 0;
-    const isCollapsed = !openedItems.includes(item.id);
-
-    const handlePress = () => {
-      if (hasChildItems) {
-        toggleCollapse(item.id);
-      } else {
-        handleOpen(item.id);
-      }
-    };
-  
-    return (
-      <View style={style}>
-        <TouchableOpacity onPress={handlePress}>
-          <View style={{ borderWidth: 1, borderRadius: 6, margin: 8, padding: 16, borderColor: '#DDD' }}>
-            <Text style={{ fontSize: 16 }}>{item.name}</Text>
-          </View>
-        </TouchableOpacity>
-        { hasChildItems && !isCollapsed && (
-          <DestinationsList style={{ marginLeft: 20 }} items={item.childs} />
-        )}
-      </View>
-    );
-  };
-
-  return (
-    <FlatList style={{}} data={items} renderItem={DestinationsListItem} />
-  );
-};
+import { DestinationEntity } from '../../core/entities/Destination';
 
 const DestinationsScreen = () => {
   const { isLoading, data } = useDestinationsList();
+  const hasDestinations = data && data.length > 0;
+
+  const mapDestinationEntityToTreeItemData = ({ id, name, childs }: DestinationEntity): TreeItemData => ({
+    id,
+    title: name,
+    childs: childs.map(mapDestinationEntityToTreeItemData),
+  });
+
+  const destinations = useMemo(() => {
+    return data ? data.map(mapDestinationEntityToTreeItemData) : [];
+  }, [data]);
+
+  const handleGoToDestination = (id: string) => {
+
+  };
 
   return (
     <Screen>
       { isLoading ? (
         <Text>Looking for destinations...</Text>
       ) : (
-        data && data.length > 0 ? (
-          <DestinationsList items={data} />
+        hasDestinations ? (
+          <TreeList items={destinations} onOpen={handleGoToDestination} />
         ) : (
           <Text>There is no destinations available to show you right now. Try again later.</Text>
         )

--- a/src/ui/screens/DestinationsScreen.tsx
+++ b/src/ui/screens/DestinationsScreen.tsx
@@ -1,32 +1,71 @@
-import React from 'react';
-import { View, FlatList, ListRenderItem, Text, TouchableOpacity } from 'react-native';
+import React, { useState } from 'react';
+import { View, FlatList, ListRenderItem, Text, TouchableOpacity, ViewStyle } from 'react-native';
 import Screen from '../components/Screen';
 import useDestinationsList from '../../core/usecases/useDestinationsList';
-import { DestinationEntity } from '../../core/entities/Destination';
+import { DestinationEntity, DestinationId } from '../../core/entities/Destination';
+import { toggleArrayItem } from '../../utils/helpers';
 
-const DestinationsListItem: ListRenderItem<DestinationEntity> = ({ item }) => {
-  return (
-    <TouchableOpacity>
-      <View style={{ borderWidth: 1, borderRadius: 6, margin: 8, padding: 16, borderColor: '#DDD' }}>
-        <Text style={{ fontSize: 16 }}>{item.name}</Text>
-      </View>
-    </TouchableOpacity>
-  );
+type DestinationsListProps = {
+  items: DestinationEntity[];
+  style?: ViewStyle;
 };
 
-const DestinationsList = () => {
-  const { isLoading, data } = useDestinationsList();
+const DestinationsList: React.FC<DestinationsListProps> = ({ items, style }) => {
+  const [openedItems, setOpenedItems] = useState<DestinationId[]>([]);
+
+  const toggleCollapse = (id: DestinationId) => {
+    setOpenedItems(prev => toggleArrayItem(prev, id));
+  };
+
+  const handleOpen = (id: DestinationId) => {
+
+  };
+
+  const DestinationsListItem: ListRenderItem<DestinationEntity> = ({ item }) => {
+    const hasChildItems = item.hasChildren && item.childs.length > 0;
+    const isCollapsed = !openedItems.includes(item.id);
+
+    const handlePress = () => {
+      if (hasChildItems) {
+        toggleCollapse(item.id);
+      } else {
+        handleOpen(item.id);
+      }
+    };
+  
+    return (
+      <View style={style}>
+        <TouchableOpacity onPress={handlePress}>
+          <View style={{ borderWidth: 1, borderRadius: 6, margin: 8, padding: 16, borderColor: '#DDD' }}>
+            <Text style={{ fontSize: 16 }}>{item.name}</Text>
+          </View>
+        </TouchableOpacity>
+        { hasChildItems && !isCollapsed && (
+          <DestinationsList style={{ marginLeft: 20 }} items={item.childs} />
+        )}
+      </View>
+    );
+  };
 
   return (
-    <FlatList style={{}} data={data} renderItem={DestinationsListItem} />
+    <FlatList style={{}} data={items} renderItem={DestinationsListItem} />
   );
 };
 
 const DestinationsScreen = () => {
+  const { isLoading, data } = useDestinationsList();
 
   return (
     <Screen>
-      <DestinationsList />
+      { isLoading ? (
+        <Text>Looking for destinations...</Text>
+      ) : (
+        data && data.length > 0 ? (
+          <DestinationsList items={data} />
+        ) : (
+          <Text>There is no destinations available to show you right now. Try again later.</Text>
+        )
+      )}
     </Screen>
   );
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,9 @@
+export const toggleArrayItem = <T>(array: T[], item: T): T[] => {
+  const itemIndex = array.indexOf(item);
+
+  if (itemIndex !== -1) {
+    return array.filter((i) => i !== item);
+  } else {
+    return [...array, item];
+  }
+};


### PR DESCRIPTION
## Qué se hizo
- Se han añadido fixtures de destino para poder testear mejor el mapper.
- Se ha creado un nuevo componente `TreeList` para listar items en forma de árbol.
- Se ha implementado el nuevo componente en la pantalla de destinos para dar soporte a los destinos con localizaciones hijas.

## Cómo se prueba
- En el listado de destinos, pulsar un destino que tenga localizaciones hijas. Por ejemplo: España.
- Se muestran las localizaciones hijas debajo del destino padre y con un margen que las diferencia del resto.
- Al pulsar nuevamente en el padre se dejan de mostrar las localizaciones hijas.

## Demo

https://github.com/whitebrand/stay-destinations/assets/2519386/f5a315b1-481c-4f45-abf7-1e10943f339d


