### PR TITLE
feat: show featured label on destinations

### DIFF
--- a/src/ui/components/Tag.styles.ts
+++ b/src/ui/components/Tag.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: 'yellow',
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 4,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+
+  label: { 
+    textTransform: 'uppercase',
+  },
+});

--- a/src/ui/components/Tag.test.tsx
+++ b/src/ui/components/Tag.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import Tag, { TagProps } from './Tag';
+
+const renderElement = (props: Partial<TagProps>) => {
+  const rendered = render(<Tag title="The tag" {...props} />);
+
+  return rendered;
+};
+
+describe('Tag Component', () => {
+  it('renders provided title', () => {
+    const { queryByText } = renderElement({ title: 'featured' });
+    expect(queryByText('featured')).not.toBeNull();
+  });
+
+  it('applies custom style provided', () => {
+    const customStyle = { backgroundColor: 'red' };
+    const { queryByTestId } = renderElement({ style: customStyle });
+    const container = queryByTestId('tag');
+    
+    expect(container?.props.style.backgroundColor).toEqual('red');
+  });
+});

--- a/src/ui/components/Tag.tsx
+++ b/src/ui/components/Tag.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, ViewStyle, StyleSheet } from 'react-native';
+import styles from './Tag.styles';
+
+export type TagProps = {
+  title: string;
+  style?: ViewStyle; 
+};
+
+const Tag: React.FC<TagProps> = ({ title, style }) => {
+  const containerCombinedStyle = StyleSheet.flatten([styles.container, style]);
+
+  return (
+    <View style={containerCombinedStyle} testID="tag">
+      <Text style={styles.label}>{title}</Text>
+    </View>
+  );
+};
+
+export default Tag;

--- a/src/ui/components/TreeList.styles.ts
+++ b/src/ui/components/TreeList.styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  itemContainer: {
+    borderWidth: 1,
+    borderRadius: 6,
+    margin: 8,
+    padding: 16,
+    borderColor: '#DDD',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+
+  itemTitle: {
+    fontSize: 16,
+  },
+});

--- a/src/ui/components/TreeList.test.tsx
+++ b/src/ui/components/TreeList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, within } from '@testing-library/react-native';
 import TreeList, { TreeItemData } from './TreeList';
 
 const ON_OPEN = jest.fn();
@@ -13,18 +13,22 @@ const FAKE_TREE_ITEM_DATA: TreeItemData[] = [
         id: '11',
         title: 'Item 1.1',
         childs: [],
+        isFeatured: false,
       },
       {
         id: '12',
         title: 'Item 1.2',
         childs: [],
+        isFeatured: false,
       },
     ],
+    isFeatured: false,
   },
   {
     id: '2',
     title: 'Item 2',
     childs: [],
+    isFeatured: true,
   },
 ];
 
@@ -71,5 +75,14 @@ describe('<TreeList /> component', () => {
     expect(queryByText('Item 1.1')).not.toBeNull();
     expect(queryByText('Item 1.2')).not.toBeNull();
     expect(ON_OPEN).not.toHaveBeenCalled();
+  });
+
+  it('shows featured tag when item has featured enabled', () => {
+    const { queryByTestId } = renderElement();
+    const itemContainer = queryByTestId('item-2');
+    const featuredTag = within(itemContainer!).queryByTestId('tag');
+
+    expect(featuredTag).not.toBeNull();
+    expect(within(featuredTag!).queryByText('featured')).not.toBeNull();
   });
 });

--- a/src/ui/components/TreeList.tsx
+++ b/src/ui/components/TreeList.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { View, FlatList, ListRenderItem, Text, TouchableOpacity, ViewStyle } from 'react-native';
+import Tag from './Tag';
 import { toggleArrayItem } from '../../utils/helpers';
+import styles from './TreeList.styles';
 
 export type TreeItemData = {
   id: string;
   title: string;
   childs: TreeItemData[];
+  isFeatured: boolean;
 };
 
 type TreeListProps = {
@@ -34,10 +37,11 @@ const TreeList: React.FC<TreeListProps> = ({ items, style, onOpen }) => {
     };
   
     return (
-      <View style={style}>
+      <View style={style} testID={`item-${item.id}`}>
         <TouchableOpacity onPress={handlePress}>
-          <View style={{ borderWidth: 1, borderRadius: 6, margin: 8, padding: 16, borderColor: '#DDD' }}>
-            <Text style={{ fontSize: 16 }}>{item.title}</Text>
+          <View style={styles.itemContainer}>
+            <Text style={styles.itemTitle}>{item.title}</Text>
+            { item.isFeatured && <Tag title="featured" style={{ marginLeft: 4 }} /> }
           </View>
         </TouchableOpacity>
         { hasChildItems && !isCollapsed && (

--- a/src/ui/screens/DestinationsScreen.tsx
+++ b/src/ui/screens/DestinationsScreen.tsx
@@ -9,10 +9,11 @@ const DestinationsScreen = () => {
   const { isLoading, data } = useDestinationsList();
   const hasDestinations = data && data.length > 0;
 
-  const mapDestinationEntityToTreeItemData = ({ id, name, childs }: DestinationEntity): TreeItemData => ({
+  const mapDestinationEntityToTreeItemData = ({ id, name, isFeatured, childs }: DestinationEntity): TreeItemData => ({
     id,
     title: name,
     childs: childs.map(mapDestinationEntityToTreeItemData),
+    isFeatured,
   });
 
   const destinations = useMemo(() => {


### PR DESCRIPTION
## Qué se hizo
- Se ha añadido un nuevo componente `Tag` que permite utilizarse a modo de etiqueta.
- Se ha modificado el componente `TreeList` para aceptar una nueva prop que permita destacar un item del árbol.

## Cómo se prueba
- En el listado de destinos dirigirse a los que son devueltos como destacados por el API. Por ejemplo: España.
- Comprobar que aparece la etiqueta FEATURED al lado del nombre.
- Comprobar que no aparece dicha etiqueta en los destinos que no son devueltos como destacados.

## Demo

https://github.com/whitebrand/stay-destinations/assets/2519386/515046f2-a478-4d8f-b707-93a1faec33ae



